### PR TITLE
fix(player): episodes query with post_date_gmt

### DIFF
--- a/src/classes/Content/Player/Player.php
+++ b/src/classes/Content/Player/Player.php
@@ -463,8 +463,8 @@ class Player {
 					// could have been imported from a third party feed that used mirrored post data that did not preserve
 					// the WordPress post guid, eg. SSP Plugin to Castos.
 					// Look for Dovetail episode with the same publish date and title...
-					if ( ! $episode_api && property_exists( $post, 'date' ) && $post->date ) {
-						list( $episode_api ) = $this->dovetail_api->get_podcast_episodes_by_publish_date_and_title( $p['id'], $post->date, $post->post_title );
+					if ( ! $episode_api && property_exists( $post, 'post_date_gmt' ) && $post->post_date_gmt ) {
+						list( $episode_api ) = $this->dovetail_api->get_podcast_episodes_by_publish_date_and_title( $p['id'], $post->post_date_gmt, $post->post_title );
 					}
 
 					if ( $episode_api ) {

--- a/src/classes/Dovetail/DovetailApi.php
+++ b/src/classes/Dovetail/DovetailApi.php
@@ -278,7 +278,7 @@ class DovetailApi {
 	 */
 	public function get_podcast_episodes_by_publish_date( int $id, string $publish_date = null ) {
 		$api_url = "https://{$this->feeder_domain}/api/v1/authorization/podcasts/{$id}/episodes";
-		$on_date = $publish_date ? new \DateTime( $publish_date ) : new \DateTime();
+		$on_date = $publish_date ? new \DateTime( $publish_date, new \DateTimeZone( 'GMT' ) ) : new \DateTime( 'now', new \DateTimeZone( 'GMT' ) );
 		$one_day = new \DateInterval( 'P1D' );
 		$after   = $on_date->format( 'Y-m-d' );
 		$before  = $on_date->add( $one_day )->format( 'Y-m-d' );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/PRX/Dovetail-Wordpress-Plugin/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our main*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!

-->

## What does this implement/fix? Explain your changes.

- Fixes discrepancy in post date property used to detect existing/imported Dovetail episodes when rendering players.
- Ensures GMT date is used by default to query episodes by published date with Dovetail API.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

No.

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots, logs, error output, etc -->

No.
