### PR TITLE
fix: Update DovetailApi to widen date range used for publish date + title queries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
             echo "Committing changes to develop first"
             git add *.php *.md *.txt package.json
             git commit -m "release: prepare v${{ steps.version_bump.outputs.version }}"
-            git push origin develop
+            git push origin HEAD
           fi
 
           # Now switch to main

--- a/src/classes/Dovetail/DovetailApi.php
+++ b/src/classes/Dovetail/DovetailApi.php
@@ -295,6 +295,32 @@ class DovetailApi {
 	}
 
 	/**
+	 * Get collection of episodes belonging to a podcast, published around a specific date.
+	 *
+	 * @param int    $id Dovetail podcast id.
+	 * @param string $publish_date Date episodes are published on.
+	 * @return array<int,array<string,mixed>|false>
+	 */
+	public function get_podcast_episodes_around_publish_date( int $id, string $publish_date = null ) {
+		$api_url = "https://{$this->feeder_domain}/api/v1/authorization/podcasts/{$id}/episodes";
+		$on_date = $publish_date ? new \DateTime( $publish_date, new \DateTimeZone( 'GMT' ) ) : new \DateTime( 'now', new \DateTimeZone( 'GMT' ) );
+		$one_day = new \DateInterval( 'P1D' );
+		$two_day = new \DateInterval( 'P2D' );
+		$after   = $on_date->sub( $one_day )->format( 'Y-m-d' );
+		$before  = $on_date->add( $two_day )->format( 'Y-m-d' );
+
+		$api_url = add_query_arg(
+			[
+				'after'  => $after,
+				'before' => $before,
+			],
+			$api_url
+		);
+
+		return $this->get( $api_url );
+	}
+
+	/**
 	 * Get collection of episodes belonging to a podcast, published on a specific date, with a specific title.
 	 *
 	 * @param int    $id Dovetail podcast id.
@@ -307,7 +333,7 @@ class DovetailApi {
 
 		// Dovetail API only has publish date filtering for podcast episodes.
 		// Fetch episodes published on post's publish data,...
-		list( $episodes_api, $api_response ) = $this->get_podcast_episodes_by_publish_date( $id, $publish_date );
+		list( $episodes_api, $api_response ) = $this->get_podcast_episodes_around_publish_date( $id, $publish_date );
 
 		if (
 			$episodes_api &&


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/PRX/Dovetail-Wordpress-Plugin/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our main*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!

-->

## What does this implement/fix? Explain your changes.

- Update DovetailApi to widen date range used for publish date + title queries to help account for date shifting due to incorrect timezone translations when importing third-party hosted feeds into Dovetail.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

No.

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots, logs, error output, etc -->

No.
