### PR TITLE
fix(postmetabox): Yoast SEO init error

### DIFF
--- a/packages/metabox/podcast-episode/src/hooks/use-editor-saving.ts
+++ b/packages/metabox/podcast-episode/src/hooks/use-editor-saving.ts
@@ -19,7 +19,7 @@ export function useEditorSaving(): [boolean,boolean] {
       const unsubscribe = wp.data.subscribe(() => {
         const select = wp.data.select('core/editor');
 
-        // console.log('wp.data.subscribe', select.getEditedPostAttribute('meta')?.['_dovetail_podcasts_episode'] );
+        if (!select) return;
 
         setIsSavingPost( select.isSavingPost() );
         setIsAutosavingPost( select.isAutosavingPost() );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/PRX/Dovetail-Wordpress-Plugin/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our main*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!

-->

## What does this implement/fix? Explain your changes.

Fixes issue that causes Yoast SEO post meta box to error when post has Dovetail Podcast Episode data.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

No.

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots, logs, error output, etc -->

No.
