### PR TITLE
fix: Settings page podcasts list thumbnails should have images when only the cover image is set on the podcast.

### DIFF
--- a/src/classes/Admin/Settings/Settings.php
+++ b/src/classes/Admin/Settings/Settings.php
@@ -353,9 +353,17 @@ class Settings {
 					</div>
 					<div class="dovetail-podcasts">
 						<?php foreach ( $podcasts['_embedded']['prx:items'] as $podcast ) : ?>
+							<?php
+							$image = false;
+							if ( isset( $podcast['itunesImage'] ) ) {
+								$image = $podcast['itunesImage'];
+							} elseif ( isset( $podcast['feedImage'] ) ) {
+								$image = $podcast['feedImage'];
+							}
+							?>
 						<span class="dovetail-podcast">
-							<?php if ( isset( $podcast['feedImage'] ) ) : ?>
-							<img class="dovetail-podcast-thumbnail" src="<?php echo esc_url( $podcast['feedImage']['href'] ); ?>" width="32" height="32" alt="Thumbnail"/>
+							<?php if ( $image ) : ?>
+							<img class="dovetail-podcast-thumbnail" src="<?php echo esc_url( $image['href'] ); ?>" width="32" height="32" alt="Thumbnail"/>
 							<?php else : ?>
 							<span class="dovetail-podcast-thumbnail dashicons-before dashicons-microphone"></span>
 							<?php endif ?>


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/PRX/Dovetail-Wordpress-Plugin/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our main*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!

-->

## What does this implement/fix? Explain your changes.

Fixes an issue with podcast list items not having thumbnail images when the podcast has only a cover image set.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

No.

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots, logs, error output, etc -->

No.
