### PR TITLE
feat: API requests always go to production Dovetail API domains

### DIFF
--- a/src/classes/Dovetail/DovetailApi.php
+++ b/src/classes/Dovetail/DovetailApi.php
@@ -71,13 +71,11 @@ class DovetailApi {
 	 * Class construct.
 	 */
 	public function __construct() {
-		$wp_environment_type = 'production';
-		if ( function_exists( 'wp_get_environment_type' ) ) {
-			$wp_environment_type = wp_get_environment_type();
-		}
 
-		$this->id_domain     = 'production' === $wp_environment_type ? 'id.prx.org' : 'id.staging.prx.tech';
-		$this->feeder_domain = 'production' === $wp_environment_type ? 'feeder.prx.org' : 'feeder.staging.prx.tech';
+		error_log( print_r( getenv(), true ) );
+
+		$this->id_domain     = getenv( 'DTPODCASTS_ID_DOMAIN' ) ?: 'id.prx.org';
+		$this->feeder_domain = getenv( 'DTPODCASTS_FEEDER_DOMAIN' ) ?: 'feeder.prx.org';
 
 		$key_ascii          = get_option( 'dovetail_podcasts_key' );
 		$client_credentials = get_option( DTPODCASTS_SETTINGS_SECTION_PREFIX . 'authentication' );

--- a/src/classes/Dovetail/DovetailApi.php
+++ b/src/classes/Dovetail/DovetailApi.php
@@ -72,8 +72,6 @@ class DovetailApi {
 	 */
 	public function __construct() {
 
-		error_log( print_r( getenv(), true ) );
-
 		$this->id_domain     = getenv( 'DTPODCASTS_ID_DOMAIN' ) ?: 'id.prx.org';
 		$this->feeder_domain = getenv( 'DTPODCASTS_FEEDER_DOMAIN' ) ?: 'feeder.prx.org';
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/PRX/Dovetail-Wordpress-Plugin/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our main*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!

-->

## What does this implement/fix? Explain your changes.

Updates DovetailApi class to use production API domains, unless a local development environment variable is set.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

No.

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots, logs, error output, etc -->

No.
