### PR TITLE
fix(postmetabox): Disable scrubbing of upload playback url

### DIFF
--- a/packages/metabox/podcast-episode/src/PostMetabox.tsx
+++ b/packages/metabox/podcast-episode/src/PostMetabox.tsx
@@ -360,21 +360,14 @@ function PostMetabox({ field, episode: _episode, options }: PostMetaboxProps) {
 
     return res.data;
   }, (data) => {
-    const { id, enclosure, uncut } = data || {};
+    const { id, enclosure } = data || {};
     const inProgressStatuses = ['created', 'processing'];
 
     if (!id || !enclosure) return !!dovetail?.id;
 
     const isEnclosureProcessing = inProgressStatuses.includes(enclosure?.status);
-    const isUncutProcessing = inProgressStatuses.includes(uncut?.status);
 
-    if (! isUncutProcessing ) {
-      dispatch({ type: 'UPDATE_EPISODE_DOVETAIL', payload: data });
-    }
-
-    if (! isEnclosureProcessing ) {
-      dispatch({ type: 'UPDATE_EPISODE_DOVETAIL', payload: data });
-    }
+    dispatch({ type: 'UPDATE_EPISODE_DOVETAIL', payload: data });
 
     return isEnclosureProcessing;
   }, 2000, [dovetail?.id, dovetail?.enclosure?.status]);

--- a/packages/metabox/podcast-episode/src/components/Enclosure/Enclosure.tsx
+++ b/packages/metabox/podcast-episode/src/components/Enclosure/Enclosure.tsx
@@ -83,7 +83,7 @@ export function Enclosure({ episode: _episode, onChange }: EnclosureProps) {
   const [status, setStatus] = useState<EnclosureStatus>(getEnclosureStatus(episode));
   const [remoteUrl, setRemoteUrl] = useState(!wasUploaded ? url : null);
   const [audioInfo, setAudioInfo] = useState<AudioInfo>({
-    duration: dovetail.enclosure?.duration || duration || 0
+    duration: dovetail.uncut?.duration || dovetail.enclosure?.duration || duration || 0
   });
   const [uploadProgress, setUploadProgress] = useState(0);
   const [seekTime, setSeekTime] = useState<number>();
@@ -91,24 +91,23 @@ export function Enclosure({ episode: _episode, onChange }: EnclosureProps) {
   const [audioCurrentTime, setAudioCurrentTime] = useState(0);
   const [editingRemoteUrl, setEditingRemoteUrl] = useState(false);
   const hasUnsavedChanges = (url !== _episode.enclosure?.url);
-  const audioSrcUrl = hasUnsavedChanges ?
+  const [audioSrcType, audioSrcUrl, audioSrcDuration] = hasUnsavedChanges ?
     // Audio has been edited. Could not have been saved yet, or is still processing.
     // Use enclosure URL when it is playable. This is for remote URL input, before saving.
-    remoteUrl ||
-    // Use dovetail uncut URL when uncut processing is complete. This is for uploads after saving while being processed.
-    (dovetail.uncut && dovetail.uncut.status === 'complete' && dovetail.uncut.href) ||
+    remoteUrl && ['remote-url', remoteUrl, audioInfo?.duration || duration] ||
+    // Use dovetail uncut URL when uncut processing is complete. This is for uploads after saving (async block-editor).
+    (dovetail.uncut && dovetail.uncut.status === 'complete' && dovetail.uncut.href && ['dovetail-href', dovetail.uncut.href, dovetail.uncut.duration]) ||
     // Use playback URL after upload for as long as it exists and has not expired. This is for uploads before saving and while being processed.
-    (playbackUrl && (!playbackExpires || playbackExpires < Date.now()) && playbackUrl) ||
+    (playbackUrl && (!playbackExpires || playbackExpires < Date.now()) && playbackUrl && ['playback-url', playbackUrl, audioInfo?.duration || duration]) ||
     // Make sure any boolean failures fall though to an undefined value.
-    undefined :
+    ['no-audio-src', undefined, 0] :
     // Otherwise, dovetail data should be saved and have accessible audio URL for processed audio.
-    // Construct a dovetail enclosure URL. We do not want use the href from the dovetail enclosure
-    // since it will be prefixed with analytics prefixes, and audio played in the admin should not
-    // affect those metrics.
-    (dovetail.uncut && dovetail.uncut.status === 'complete' && dovetail.uncut.href) ||
+    // Use uncut href when processing is complete. We do not want use the href from the dovetail enclosure since it will be
+    // contain analytics prefixes, and audio played in the admin should not affect those metrics.
+    (dovetail.uncut && dovetail.uncut.status === 'complete' && dovetail.uncut.href && ['dovetail-href', dovetail.uncut.href, dovetail.uncut.duration]) ||
     // Legacy fallback to media for the brief period when the Dovetail API didn't support the `uncut` property.
-    dovetail.enclosure?.status === 'complete' && dovetail.media?.[0].href ||
-    undefined;
+    dovetail.enclosure?.status === 'complete' && dovetail.media?.[0].href && ['dovetail-href', dovetail.media[0].href, dovetail.media[0].duration] ||
+    ['no-audio-src', undefined, 0];
   const audioIsPlayable = `${audioSrcUrl}`.startsWith('http');
 
   const openFileDialog = useCallback(() => {
@@ -565,7 +564,7 @@ export function Enclosure({ episode: _episode, onChange }: EnclosureProps) {
             {info || (
               <div className='grid gap-2'>
                 <div className='flex flex-wrap gap-2'>
-                  { audioInfo?.duration ? <Badge variant='secondary'>{formatDuration(audioInfo.duration)}</Badge> : <Skeleton className='w-[8ch] h-[1em]' /> }
+                  { !!audioSrcDuration && <Badge variant='secondary'>{formatDuration(audioSrcDuration)}</Badge> }
                   { 'dovetail-processing' === status && <Badge variant='outline'><LoaderIcon className='text-sky-500 animate-spin' />Dovetail Processing Audio...</Badge> }
                   { 'dovetail-complete' === status && !hasUnsavedChanges && <Badge variant='outline'><CircleCheckBigIcon className='text-green-500' />Dovetail Audio {'publish' === postStatus ? 'Published' : 'Ready'}</Badge> }
                   { !!dovetail?.enclosure?.size && 'dovetail-incomplete' === status && (
@@ -610,28 +609,31 @@ export function Enclosure({ episode: _episode, onChange }: EnclosureProps) {
                     </Tooltip>
                   )}
                 </div>
-                <div className='flex items-center gap-3'>
-                  <Button type='button' size='icon' variant='ghost' className='rounded-full aspect-square' aria-label='Return To Beginning'
-                    onClick={() => {
-                      audioRef.current.currentTime = 0;
-                    }}
-                  ><SkipBackIcon /></Button>
-                  <Slider min={0} max={audioInfo.duration} step={0.1} value={[seekTime || audioCurrentTime]}
-                    onValueChange={(v) => {
-                      setSeekTime(v[0]);
-                    }}
-                    onValueCommit={(v) => {
-                      setSeekTime(null);
-                      setAudioCurrentTime(v[0]);
-                      audioRef.current.currentTime = v[0];
-                    }}
-                  />
-                  <span className='flex items-center gap-1 h-[1em] font-mono'>
-                    <span>{formatDuration(seekTime || audioCurrentTime)}</span>
-                    <Separator orientation='vertical' />
-                    <span className='text-gray-300'>{formatDuration(audioInfo.duration)}</span>
-                  </span>
-                </div>
+                {!!audioSrcDuration && (
+                  <div className='flex items-center gap-3'>
+                    <Button type='button' size='icon' variant='ghost' className='rounded-full aspect-square' aria-label='Return To Beginning'
+                      onClick={() => {
+                        audioRef.current.currentTime = 0;
+                      }}
+                    ><SkipBackIcon /></Button>
+                    <Slider min={0} max={audioSrcDuration || 0} step={0.1} value={[seekTime || audioCurrentTime]}
+                      disabled={['playback-url', 'no-audio-src'].includes(audioSrcType)}
+                      onValueChange={(v) => {
+                        setSeekTime(v[0]);
+                      }}
+                      onValueCommit={(v) => {
+                        setSeekTime(null);
+                        setAudioCurrentTime(v[0]);
+                        audioRef.current.currentTime = v[0];
+                      }}
+                    />
+                    <span className='flex items-center gap-1 h-[1em] font-mono'>
+                      <span>{formatDuration(seekTime || audioCurrentTime)}</span>
+                      <Separator orientation='vertical' />
+                      <span className='text-gray-300'>{formatDuration(audioSrcDuration || 0)}</span>
+                    </span>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/packages/metabox/podcast-episode/src/components/ui/slider.tsx
+++ b/packages/metabox/podcast-episode/src/components/ui/slider.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils"
 
 function Slider({
   className,
+  disabled,
   defaultValue,
   value,
   min = 0,
@@ -24,6 +25,7 @@ function Slider({
   return (
     <SliderPrimitive.Root
       data-slot="slider"
+      disabled={disabled}
       defaultValue={defaultValue}
       value={value}
       min={min}
@@ -47,7 +49,7 @@ function Slider({
           )}
         />
       </SliderPrimitive.Track>
-      {Array.from({ length: _values.length }, (_, index) => (
+      {!disabled && Array.from({ length: _values.length }, (_, index) => (
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}

--- a/src/classes/Content/Player/Player.php
+++ b/src/classes/Content/Player/Player.php
@@ -522,31 +522,27 @@ class Player {
 			update_post_meta( $post->ID, DTPODCASTS_POST_META_KEY, $meta );
 		}
 
+		/**
+		 * Default to uncut data when.
+		 * - Uncut processing is complete.
+		 */
+		if ( isset( $meta['dovetail']['uncut']['status'] ) && 'complete' === $meta['dovetail']['uncut']['status'] ) {
+			$atts['src']      = $meta['dovetail']['uncut']['href'];
+			$atts['duration'] = $meta['dovetail']['uncut']['duration'];
+		}
+
 		// When post is published...
 		if ( 'publish' === $post->post_status ) {
 			/**
 			 * Return Dovetail enclosure data when:
 			 * - Dovetail Enclosure data exists.
-			 * - Audio has been processed
-			 *   - `size` is > 0. Initial enclosure processing will have an href, but the URL will not return audio.
 			 */
 			if (
-				isset( $meta['dovetail']['enclosure'] ) && ! empty( $meta['dovetail']['enclosure'] ) &&
-				$meta['dovetail']['enclosure']['size'] > 0
+				isset( $meta['dovetail']['enclosure'] ) && ! empty( $meta['dovetail']['enclosure'] )
 			) {
-				// TODO: Get latest prefix from podcast and construct fresh href.
 				$atts['src']      = $meta['dovetail']['enclosure']['href'];
 				$atts['duration'] = $meta['dovetail']['enclosure']['duration'];
 			}
-		}
-
-		/**
-		 * When we do not have attrs at this point, return uncut data when.
-		 * - Uncut processing is complete.
-		 */
-		if ( ! isset( $atts['src'] ) && isset( $meta['dovetail']['uncut']['status'] ) && 'complete' === $meta['dovetail']['uncut']['status'] ) {
-			$atts['src']      = $meta['dovetail']['uncut']['href'];
-			$atts['duration'] = $meta['dovetail']['uncut']['duration'];
 		}
 
 		return $atts;

--- a/src/classes/Dovetail/DovetailApi.php
+++ b/src/classes/Dovetail/DovetailApi.php
@@ -174,6 +174,16 @@ class DovetailApi {
 		$return              = false;
 
 		if ( is_array( $data ) && ! empty( $data ) ) {
+			if ( isset( $data['uncut'] ) && is_array( $data['uncut'] ) ) {
+				$data['uncut']['duration'] = (float) $data['uncut']['duration'];
+			}
+
+			if ( isset( $data['media'] ) && is_array( $data['media'] ) ) {
+				foreach ( $data['media'] as $i => $media ) {
+					$data['media'][ $i ]['duration'] = (float) $media['duration'];
+				}
+			}
+
 			$return = [
 				'id'              => $data['id'],
 				'enclosure'       => $data['_links']['enclosure'],


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/PRX/Dovetail-Wordpress-Plugin/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our main*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!

-->

## What does this implement/fix? Explain your changes.

- Disables scrubbing of uploaded file preview URL prior to changes being saved to ensure CORS errors do not prevent playback all together.
- Published post should always render player regardless of processing status.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

No.

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots, logs, error output, etc -->

New podcasts posts that are immediately published before Dovetail processing is complete may render broken players until processing is complete. This ensures post pages with long CDN caching rules get cached with a player that should eventually play audio.
